### PR TITLE
Auth login

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,7 @@ enum VerificationTokenScope {
   VERIFICATION
   EDIT
   MFA
+  MFA_DISABLE
 }
 
 model verification_token {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,8 @@ model user {
   created_at         DateTime             @default(now())
   updated_at         DateTime             @updatedAt
   last_login_at      DateTime?
+  mfa_enabled        Boolean              @default(false)
+  mfa_enabled_at     DateTime?             
   verification_token verification_token[]
 
   @@index([email])

--- a/src/auth-users/auth-users.controller.ts
+++ b/src/auth-users/auth-users.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Post, Request, UseGuards } from '@nestjs/common';
 import { SignUpEmailDto } from './dto/sign-up/sign-up-email.dto';
 import { GetUserMetaData } from 'src/decorators/get-user-metadata';
 import { UserMetaData } from 'src/utils/types/user-metadata';
@@ -6,7 +6,11 @@ import { AuthUsersService } from './auth-users.service';
 import { VerifyTokenDto } from './dto/verify-token/verify-token.dto';
 import { CredentialsSignInDto } from './dto/sign-in/credentials-sign-in.dto';
 import { PublicOnlyGuard } from './guards/public-only.guard';
+import { PrivateOnlyGuard } from './guards/private-only.guard';
+import { JWTGuard } from './guards/jwt-auth.guard';
+import { UserSessionToken } from 'src/utils/types/user-session-token';
 
+@UseGuards(JWTGuard)
 @Controller('api/auth')
 export class AuthUsersController {
     constructor(
@@ -26,6 +30,12 @@ export class AuthUsersController {
     @Post('/sign-in/email')
     async CredentialsSigin(@Body() data:CredentialsSignInDto,@GetUserMetaData() metadata:UserMetaData){
        return this.AuthService.CredentialsUserSign(metadata,data)
+    }
+    @UseGuards(PrivateOnlyGuard)
+    @Post('/enable/mfa')
+    async Test(@Request() req,){
+      const session:UserSessionToken = req['user']
+      return this.AuthService.EnableUserMfa(session)
     }
     
 }

--- a/src/auth-users/auth-users.controller.ts
+++ b/src/auth-users/auth-users.controller.ts
@@ -4,6 +4,7 @@ import { GetUserMetaData } from 'src/decorators/get-user-metadata';
 import { UserMetaData } from 'src/utils/types/user-metadata';
 import { AuthUsersService } from './auth-users.service';
 import { VerifyTokenDto } from './dto/verify-token/verify-token.dto';
+import { CredentialsSignInDto } from './dto/sign-in/credentials-sign-in.dto';
 
 @Controller('api/auth')
 export class AuthUsersController {
@@ -18,6 +19,10 @@ export class AuthUsersController {
     @Post('/verify/email')
     async VerifyUser(@Body() data:VerifyTokenDto,@GetUserMetaData() metadata:UserMetaData){
        return this.AuthService.VerifyUserEmail(metadata,data)
+    }
+    @Post('/sign-in/email')
+    async CredentialsSigin(@Body() data:CredentialsSignInDto,@GetUserMetaData() metadata:UserMetaData){
+       return this.AuthService.CredentialsUserSign(metadata,data)
     }
     
 }

--- a/src/auth-users/auth-users.controller.ts
+++ b/src/auth-users/auth-users.controller.ts
@@ -10,7 +10,6 @@ import { PrivateOnlyGuard } from './guards/private-only.guard';
 import { JWTGuard } from './guards/jwt-auth.guard';
 import { UserSessionToken } from 'src/utils/types/user-session-token';
 
-@UseGuards(JWTGuard)
 @Controller('api/auth')
 export class AuthUsersController {
     constructor(
@@ -31,7 +30,7 @@ export class AuthUsersController {
     async CredentialsSigin(@Body() data:CredentialsSignInDto,@GetUserMetaData() metadata:UserMetaData){
        return this.AuthService.CredentialsUserSign(metadata,data)
     }
-    @UseGuards(PrivateOnlyGuard)
+    @UseGuards(JWTGuard)
     @Post('/enable/mfa')
     async Test(@Request() req,){
       const session:UserSessionToken = req['user']

--- a/src/auth-users/auth-users.controller.ts
+++ b/src/auth-users/auth-users.controller.ts
@@ -1,16 +1,18 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { SignUpEmailDto } from './dto/sign-up/sign-up-email.dto';
 import { GetUserMetaData } from 'src/decorators/get-user-metadata';
 import { UserMetaData } from 'src/utils/types/user-metadata';
 import { AuthUsersService } from './auth-users.service';
 import { VerifyTokenDto } from './dto/verify-token/verify-token.dto';
 import { CredentialsSignInDto } from './dto/sign-in/credentials-sign-in.dto';
+import { PublicOnlyGuard } from './guards/public-only.guard';
 
 @Controller('api/auth')
 export class AuthUsersController {
     constructor(
         private readonly AuthService:AuthUsersService
     ){}
+    @UseGuards(PublicOnlyGuard)
     @Post('/sign-up/email')
     async SignUpUser(@Body() data:SignUpEmailDto,@GetUserMetaData() metadata:UserMetaData){
        return this.AuthService.SignUpWithEmail(metadata,data)
@@ -20,6 +22,7 @@ export class AuthUsersController {
     async VerifyUser(@Body() data:VerifyTokenDto,@GetUserMetaData() metadata:UserMetaData){
        return this.AuthService.VerifyUserEmail(metadata,data)
     }
+   @UseGuards(PublicOnlyGuard)
     @Post('/sign-in/email')
     async CredentialsSigin(@Body() data:CredentialsSignInDto,@GetUserMetaData() metadata:UserMetaData){
        return this.AuthService.CredentialsUserSign(metadata,data)

--- a/src/auth-users/auth-users.controller.ts
+++ b/src/auth-users/auth-users.controller.ts
@@ -9,6 +9,7 @@ import { PublicOnlyGuard } from './guards/public-only.guard';
 import { PrivateOnlyGuard } from './guards/private-only.guard';
 import { JWTGuard } from './guards/jwt-auth.guard';
 import { UserSessionToken } from 'src/utils/types/user-session-token';
+import { DisableMfaDto } from './dto/disable-mfa/disable-mfa.token';
 
 @Controller('api/auth')
 export class AuthUsersController {
@@ -32,9 +33,15 @@ export class AuthUsersController {
     }
     @UseGuards(JWTGuard)
     @Post('/enable/mfa')
-    async Test(@Request() req,){
+    async EnableMfa(@Request() req,){
       const session:UserSessionToken = req['user']
       return this.AuthService.EnableUserMfa(session)
+    }
+    @UseGuards(JWTGuard)
+    @Post('/disable/mfa')
+    async DisableMfa(@Request() req,@GetUserMetaData() metadata:UserMetaData,@Body() data:DisableMfaDto,){
+      const session:UserSessionToken = req['user']
+      return this.AuthService.DisableUserMfa(session,metadata,data)
     }
     
 }

--- a/src/auth-users/auth-users.service.ts
+++ b/src/auth-users/auth-users.service.ts
@@ -10,6 +10,8 @@ import { GetJwtPayloadFromSession } from 'src/utils/others/get-jwt-payload-from-
 import { CredentialsSignInDto } from './dto/sign-in/credentials-sign-in.dto';
 import { CrendentialsSignIn } from './services/credentials-signin.service';
 import { CreateCredentialsJwtToken } from 'src/utils/others/create-jwt-token';
+import { UserSessionToken } from 'src/utils/types/user-session-token';
+import { EnabledMfa } from './services/enable-mfa.service';
 
 @Injectable()
 export class AuthUsersService {
@@ -36,5 +38,8 @@ export class AuthUsersService {
         }
         const jwt_payload =await GetJwtPayloadFromSession(response.session)
         return CreateCredentialsJwtToken(this.jwtService,jwt_payload)
+    }
+    async EnableUserMfa(session:UserSessionToken){
+        return EnabledMfa(this.prisma,session.session_id,session.user_id)
     }
 }

--- a/src/auth-users/auth-users.service.ts
+++ b/src/auth-users/auth-users.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateUser } from './services/create-user.service';
 import { UserMetaData } from 'src/utils/types/user-metadata';
@@ -6,6 +6,10 @@ import { SignUpEmailDto } from './dto/sign-up/sign-up-email.dto';
 import { VerifyTokenDto } from './dto/verify-token/verify-token.dto';
 import { VerifyUserEmailAndLogin } from './services/verifiy-user-email.service';
 import { JwtService } from '@nestjs/jwt';
+import { GetJwtPayloadFromSession } from 'src/utils/others/get-jwt-payload-from-session';
+import { CredentialsSignInDto } from './dto/sign-in/credentials-sign-in.dto';
+import { CrendentialsSignIn } from './services/credentials-signin.service';
+import { CreateCredentialsJwtToken } from 'src/utils/others/create-jwt-token';
 
 @Injectable()
 export class AuthUsersService {
@@ -22,15 +26,15 @@ export class AuthUsersService {
     }
     async VerifyUserEmail(metadata:UserMetaData,data:VerifyTokenDto){
         const session = await VerifyUserEmailAndLogin(this.prisma,data.userId,data.tokenId,data.code,metadata);
-        const jwt_payload = {
-            session_id:session.id,
-            used_id:session.user_id,
-            expires_at:session.expires_at
-        };
-        const jwtToken = this.jwtService.sign(jwt_payload)
-        return {
-            success:true,
-            token:jwtToken
+        const jwt_payload = GetJwtPayloadFromSession(session)
+        return CreateCredentialsJwtToken(this.jwtService,jwt_payload)
+    }
+    async CredentialsUserSign(metadata:UserMetaData,data:CredentialsSignInDto){
+        const response = await CrendentialsSignIn(this.prisma,data,metadata);
+        if(response.mfa_enabled || !response.session){
+           throw new InternalServerErrorException("mfa service not available yet") 
         }
+        const jwt_payload =await GetJwtPayloadFromSession(response.session)
+        return CreateCredentialsJwtToken(this.jwtService,jwt_payload)
     }
 }

--- a/src/auth-users/auth-users.service.ts
+++ b/src/auth-users/auth-users.service.ts
@@ -12,6 +12,8 @@ import { CrendentialsSignIn } from './services/credentials-signin.service';
 import { CreateCredentialsJwtToken } from 'src/utils/others/create-jwt-token';
 import { UserSessionToken } from 'src/utils/types/user-session-token';
 import { EnabledMfa } from './services/enable-mfa.service';
+import { DisableMfaDto } from './dto/disable-mfa/disable-mfa.token';
+import { DisableMfa } from './services/disable-mfa.service';
 
 @Injectable()
 export class AuthUsersService {
@@ -45,5 +47,8 @@ export class AuthUsersService {
     }
     async EnableUserMfa(session:UserSessionToken){
         return EnabledMfa(this.prisma,session.session_id,session.user_id)
+    }
+    async DisableUserMfa(session:UserSessionToken,metadata:UserMetaData,data:DisableMfaDto){
+        return DisableMfa(this.prisma,session.user_id,metadata,data)
     }
 }

--- a/src/auth-users/auth-users.service.ts
+++ b/src/auth-users/auth-users.service.ts
@@ -34,7 +34,11 @@ export class AuthUsersService {
     async CredentialsUserSign(metadata:UserMetaData,data:CredentialsSignInDto){
         const response = await CrendentialsSignIn(this.prisma,data,metadata);
         if(response.mfa_enabled || !response.session){
-           throw new InternalServerErrorException("mfa service not available yet") 
+           return {
+            mfa_enabled:true,
+            success:true,
+            mfa_token:response.mfa_token
+           }
         }
         const jwt_payload =await GetJwtPayloadFromSession(response.session)
         return CreateCredentialsJwtToken(this.jwtService,jwt_payload)

--- a/src/auth-users/dto/disable-mfa/disable-mfa.token.ts
+++ b/src/auth-users/dto/disable-mfa/disable-mfa.token.ts
@@ -1,0 +1,13 @@
+import { IsOptional, IsString, IsUUID, Length } from 'class-validator';
+
+export class DisableMfaDto {
+  @IsOptional()
+  @IsString()
+  @Length(6, 6, { message: 'Code must be exactly 6 characters long' })
+  code?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsUUID()
+  token:string
+}

--- a/src/auth-users/dto/sign-in/credentials-sign-in.dto.ts
+++ b/src/auth-users/dto/sign-in/credentials-sign-in.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsOptional, IsString } from "class-validator"
+import { IsEmail, IsOptional, IsString, Length } from "class-validator"
 
 export class CredentialsSignInDto {
        @IsEmail()
@@ -11,6 +11,7 @@ export class CredentialsSignInDto {
         //mfa enabled sign-in
         @IsString()
         @IsOptional()
+        @Length(6, 6, { message: 'Code must be exactly 6 characters long' })
         code:string
         
         //mfa enabled sign-in

--- a/src/auth-users/dto/verify-token/verify-token.dto.ts
+++ b/src/auth-users/dto/verify-token/verify-token.dto.ts
@@ -1,10 +1,9 @@
-import { IsString, IsUUID, MaxLength, MinLength } from "class-validator";
+import { IsString, IsUUID, Length, MaxLength, MinLength } from "class-validator";
 
 export class VerifyTokenDto {
 
     @IsString()
-    @MaxLength(6)
-    @MinLength(6)
+    @Length(6, 6, { message: 'Code must be exactly 6 characters long' })
     code:string
 
     @IsString()

--- a/src/auth-users/guards/private-only.guard.ts
+++ b/src/auth-users/guards/private-only.guard.ts
@@ -1,0 +1,25 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+
+@Injectable()
+export class PrivateOnlyGuard implements CanActivate{
+    constructor(private readonly jwtService:JwtService){}
+    canActivate(ctx:ExecutionContext){
+    const req = ctx.switchToHttp().getRequest<Request>();
+    const authHeader = req.headers['authorization'];
+    if (!authHeader) {
+      return false
+    }
+    const [type, token] = authHeader.split(' ');
+      if (type !== 'Bearer' || !token) {
+      return false
+    }
+    try {
+     this.jwtService.verify(token);
+    
+      return true
+    } catch (err) {
+      return false
+    }
+    }
+}

--- a/src/auth-users/guards/public-only.guard.ts
+++ b/src/auth-users/guards/public-only.guard.ts
@@ -1,0 +1,25 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+
+@Injectable()
+export class PublicOnlyGuard implements CanActivate{
+    constructor(private readonly jwtService:JwtService){}
+    canActivate(ctx:ExecutionContext){
+    const req = ctx.switchToHttp().getRequest<Request>();
+    const authHeader = req.headers['authorization'];
+    if (!authHeader) {
+      return true;
+    }
+    const [type, token] = authHeader.split(' ');
+      if (type !== 'Bearer' || !token) {
+      return true;
+    }
+    try {
+      this.jwtService.verify(token);
+      
+      return false
+    } catch (err) {
+      return true;
+    }
+    }
+}

--- a/src/auth-users/services/credentials-signin.service.ts
+++ b/src/auth-users/services/credentials-signin.service.ts
@@ -1,0 +1,42 @@
+import { PrismaClient } from "@prisma/client";
+import { CredentialsSignInDto } from "../dto/sign-in/credentials-sign-in.dto";
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { verify } from "argon2";
+import { UserMetaData } from "src/utils/types/user-metadata";
+import { fifteenDaysFromNow } from "src/utils/others/date-utils";
+import { cacheUser } from "src/utils/redis/cache-user";
+
+export const CrendentialsSignIn = async(prisma:PrismaClient,data:CredentialsSignInDto,metadata:UserMetaData)=>{
+    const user =await prisma.user.findUnique({
+        where:{
+            email:data.email
+        }
+    });
+    if(!metadata.ip||!metadata.user_agent) throw new BadRequestException("invalid request")
+    if(!user||!user.hashed_password) throw new BadRequestException("invalid credentials")
+    const isCorrectPassword = await verify(user.hashed_password,data.password)
+    if(!isCorrectPassword)  throw new BadRequestException("invalid credentials")
+    //mfa is not yet implemented
+    const isMfaEnabled = false;
+    if(!isMfaEnabled){
+     const session = await prisma.session.create({
+        data:{
+            user_id:user.id,
+            ip:metadata.ip,
+            user_agent:metadata.user_agent,
+            expires_at:fifteenDaysFromNow()
+        }
+     });
+     await cacheUser(user)
+     return {
+        session,
+        mfa_token:null,
+        mfa_enabled:false
+     }
+    }
+    return {
+        session:null,
+          mfa_token:'',
+        mfa_enabled:true
+    }
+}

--- a/src/auth-users/services/disable-mfa.service.ts
+++ b/src/auth-users/services/disable-mfa.service.ts
@@ -1,0 +1,74 @@
+import { PrismaClient } from "@prisma/client";
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { cacheUser } from "src/utils/redis/cache-user";
+import { verify } from "argon2";
+import { GenerateOtpSecret } from "src/utils/others/encrypt-secret";
+import { fifteenMinsFromNow } from "src/utils/others/date-utils";
+import { DisableMfaDto } from "../dto/disable-mfa/disable-mfa.token";
+import { UserMetaData } from "src/utils/types/user-metadata";
+
+export const DisableMfa = async (
+  prisma: PrismaClient,
+  userId: string,
+  metadata: UserMetaData,
+  data?:DisableMfaDto
+) => {
+    if(!metadata.ip||!metadata.user_agent) throw new BadRequestException("invalid request")
+  // 1️⃣ Verify user exists
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new NotFoundException("User not found");
+  if (!user.mfa_enabled) throw new BadRequestException("MFA is not enabled");
+
+  // 2️⃣ No code submitted → generate MFA disable token
+  if (!data?.code) {
+    const otp = await GenerateOtpSecret(); // { secret, token }
+    const verificationToken = await prisma.verification_token.create({
+      data: {
+        user_id: user.id,
+        ip: metadata.ip,
+        user_agent: metadata.user_agent,
+        secret: otp.secret,
+        expires_at: fifteenMinsFromNow(),
+        scope: "MFA_DISABLE",
+      },
+    });
+    //TODO send email
+    console.log(otp)
+    return {
+      mfa_token: verificationToken.id,
+    };
+  }
+
+  // 3️⃣ Code submitted → verify token
+  const tokenRecord = await prisma.verification_token.findFirst({
+    where: {
+      user_id: user.id,
+      scope: "MFA_DISABLE",
+      expires_at: { gt: new Date() },
+      id:data.token
+    },
+    orderBy: { created_at: "desc" },
+  });
+
+  if (!tokenRecord) throw new NotFoundException("MFA token not found or expired");
+
+  const isValid = await verify(tokenRecord.secret, data.code);
+  if (!isValid) throw new BadRequestException("Invalid MFA code");
+
+  const updatedUser = await prisma.user.update({
+    where: { id: user.id },
+    data: {
+      mfa_enabled: false,
+      mfa_enabled_at: null,
+    },
+  });
+
+  await prisma.verification_token.delete({ where: { id: tokenRecord.id } });
+
+  await cacheUser(updatedUser);
+
+  return {
+    mfa_enabled: updatedUser.mfa_enabled,
+    mfa_enabled_at: updatedUser.mfa_enabled_at,
+  };
+};

--- a/src/auth-users/services/enable-mfa.service.ts
+++ b/src/auth-users/services/enable-mfa.service.ts
@@ -1,0 +1,24 @@
+import { PrismaClient } from "@prisma/client";
+import { GetSessionById } from "src/utils/others/get-session";
+import { GetUserById } from "./get-user-by-id.service";
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { cacheUser } from "src/utils/redis/cache-user";
+export const EnabledMfa = async(prisma:PrismaClient ,token:string,user_id:string)=>{
+    const session = await GetSessionById(prisma,token,user_id);
+    const user = await GetUserById(prisma,session.user_id)
+    if(!user) throw new NotFoundException("user not found");
+    if(user.mfa_enabled) throw  new BadRequestException("mfa already enabled")
+    const updated_user = await prisma.user.update({where:{
+        id:user.id},
+    data:{
+        mfa_enabled:true,
+        mfa_enabled_at:new Date()
+    }
+    });
+    cacheUser(updated_user)
+    const {mfa_enabled,mfa_enabled_at} =updated_user
+    return {
+        mfa_enabled,
+        mfa_enabled_at
+    }
+}

--- a/src/auth-users/services/get-user-by-id.service.ts
+++ b/src/auth-users/services/get-user-by-id.service.ts
@@ -1,0 +1,22 @@
+import { PrismaClient, user } from "@prisma/client"
+import { redis } from "src/utils/others/redis";
+import { cacheUser } from "src/utils/redis/cache-user";
+
+export const GetUserById = async(prisma:PrismaClient,id:string)=>{
+    const cache:user|null = await redis.get(id)
+    if(cache){
+        return cache
+    }
+
+    const exiting_user =  await prisma.user.findUnique({
+        where:{
+             id
+        }
+    });
+    if(exiting_user){
+        await cacheUser(exiting_user)
+        return exiting_user
+    }
+    return null
+
+}

--- a/src/utils/others/create-jwt-token.ts
+++ b/src/utils/others/create-jwt-token.ts
@@ -1,0 +1,9 @@
+import { JwtService } from "@nestjs/jwt";
+
+export const CreateCredentialsJwtToken= async(jwtService:JwtService,jwt_payload:any)=>{
+ const jwtToken = jwtService.sign(jwt_payload)
+        return {
+            success:true,
+            token:jwtToken
+        }
+}  

--- a/src/utils/others/get-jwt-payload-from-session.ts
+++ b/src/utils/others/get-jwt-payload-from-session.ts
@@ -1,0 +1,9 @@
+import { session } from "@prisma/client";
+
+export const GetJwtPayloadFromSession =async(session:session)=>{
+    return{
+        session_id:session.id,
+        user_id:session.user_id,
+        expires_at:session.expires_at
+    }
+}

--- a/src/utils/types/user-session-token.ts
+++ b/src/utils/types/user-session-token.ts
@@ -1,0 +1,5 @@
+export type UserSessionToken ={
+    session_id:string,
+    user_id:string,
+    expires_at:Date
+}


### PR DESCRIPTION
# PR: Add MFA Enable, Disable, and Login Flow  

## Changes Introduced

- **Enable MFA**  
  - Generates verification token for enabling MFA.  
  - Updates `mfa_enabled` and `mfa_enabled_at` after verification.  
  - Caches updated user in Redis.  

- **Disable MFA**  
  - Two-step flow:  
    1. Generate MFA disable token if no OTP provided.  
    2. Verify submitted OTP and disable MFA.  
  - Checks user existence while generating or disabling MFA.  
  - Only non-expired tokens are accepted.  

- **MFA Login Flow**  
  - Users with MFA enabled receive a temporary MFA token after password verification.  
  - Final login only succeeds after OTP verification.  

- **Implementation Notes**  
  - OTPs hashed with `argon2` and stored in `verification_token` table.  
  - Tokens expire in 15 minutes.  
  - Consistent metadata (`ip`, `user_agent`) stored for auditing.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added email/password sign-in with MFA support.
  - Enable or disable MFA from your account; receive an MFA challenge when required.
  - Issues session-based JWTs after successful sign-in.

- Improvements
  - Clearer validation for MFA codes (exactly 6 characters) with user-friendly error messages.

- Security
  - Sign-up and sign-in guarded to prevent access when already authenticated.
  - MFA actions now require authentication and are protected by JWT.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->